### PR TITLE
Added texture to bumpMap property

### DIFF
--- a/PsycheProj/index.js
+++ b/PsycheProj/index.js
@@ -428,6 +428,7 @@ function loadModel(currentModelState, appStart = true, position = null) {
             currentObject.traverse ( ( o ) => {
                 if ( o.isMesh ) {
                     o.material.map = texture;
+                    o.material.bumpMap = texture;
                 }
             } );
 


### PR DESCRIPTION
Each Mesh has a Material and the Material has a property called bumpMap -- this affects how light and shadows are projected on the object. Adding our texture to the bumpMap property of the material of the meshes makes gives the meshes more dimension, which in this case adds to the "3D pixel art" quality that we're going for. Cool!