### PR TITLE
text typo fix, opaque start button

### DIFF
--- a/PsycheProj/non-AR-text-version.html
+++ b/PsycheProj/non-AR-text-version.html
@@ -107,7 +107,7 @@
 
                         <h5>HOW WILL THE PSYCHE MISSION COLLECT DATA?</h5>
                         <p>
-                            The spacecraft is equpped with two Multispectral Imagers. These high 
+                            The spacecraft is equipped with two Multispectral Imagers. These high 
                             resolution cameras will capture images of the asteroid's surface at different wavelengths of 
                             light. This, along with pictures of the topography of Psyche, will allow scientists to study 
                             features that provide clues to Psyche's history. 

--- a/PsycheProj/src/scripts/jsm/webxr/ARButton.js
+++ b/PsycheProj/src/scripts/jsm/webxr/ARButton.js
@@ -68,12 +68,13 @@ class ARButton {
 			element.style.padding = '12px 6px';
 			element.style.border = '1px solid #fff';
 			element.style.borderRadius = '4px';
-			element.style.background = 'rgba(0,0,0,0.1)';
+			element.style.background = 'rgba(0,0,0,1)';
 			element.style.color = '#fff';
 			element.style.font = 'normal 13px sans-serif';
 			element.style.textAlign = 'center';
-			element.style.opacity = '0.5';
+			element.style.opacity = '1';
 			element.style.outline = 'none';
+			element.style.boxShadow = "2px 2px 4px rgba(0, 0, 0, 0.3)";
 			element.style.zIndex = '999';
 
 		}

--- a/PsycheProj/src/scripts/text.js
+++ b/PsycheProj/src/scripts/text.js
@@ -37,7 +37,7 @@ const facts = [
         "How might Psyche have formed?",
 
         // Model 1 - Spacecraft Button - String Array indicates it will use multiple speech boxes.
-        ["The spacecraft will is equipped with two Multispectral Imagers. These high resolution cameras will capture images of the asteroid's surface at",
+        ["The spacecraft is equipped with two Multispectral Imagers. These high resolution cameras will capture images of the asteroid's surface at",
         "different wavelengths of light. This, along with pictures of the topography of Psyche, will allow scientists to study features that provide",
         "clues to Psyche's history."]
     ],


### PR DESCRIPTION
- made start button opaque in case button appears over background in an undesired way, so it will still be readable